### PR TITLE
docs: fix typos in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # garif
 
-A GO package to create and manipulate SARIF logs.
+A Go package to create and manipulate SARIF logs.
 
 SARIF, from _Static Analysis Results Interchange Format_, is a standard JSON-based format for the output of static analysis tools defined and promoted by [OASIS](https://www.oasis-open.org/).
 

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Package garif defines all the GO structures required to model a SARIF log file.
+// Package garif defines all the Go structures required to model a SARIF log file.
 // These structures were created using the JSON-schema sarif-schema-2.1.0.json of SARIF logfiles
 // available at https://github.com/oasis-tcs/sarif-spec/tree/master/Schemata.
 //

--- a/models.go
+++ b/models.go
@@ -273,7 +273,7 @@ type ExternalProperties struct {
 	// An array of graph objects that will be merged with a separate run.
 	Graphs []*Graph `json:"graphs,omitempty"`
 
-	// A stable, unique identifer for this external properties object, in the form of a GUID.
+	// A stable, unique identifier for this external properties object, in the form of a GUID.
 	Guid string `json:"guid,omitempty"`
 
 	// Describes the invocation of the analysis tool that will be merged with a separate run.
@@ -291,7 +291,7 @@ type ExternalProperties struct {
 	// An array of result objects that will be merged with a separate run.
 	Results []*Result `json:"results,omitempty"`
 
-	// A stable, unique identifer for the run associated with this external properties object, in the form of a GUID.
+	// A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.
 	RunGuid string `json:"runGuid,omitempty"`
 
 	// The URI of the JSON schema corresponding to the version of the external property file format.
@@ -319,7 +319,7 @@ type ExternalProperties struct {
 // ExternalPropertyFileReference Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.
 type ExternalPropertyFileReference struct {
 
-	// A stable, unique identifer for the external property file in the form of a GUID.
+	// A stable, unique identifier for the external property file in the form of a GUID.
 	Guid string `json:"guid,omitempty"`
 
 	// A non-negative integer specifying the number of items contained in the external property file.
@@ -835,7 +835,7 @@ type ReportingDescriptor struct {
 	// A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result.
 	FullDescription *MultiformatMessageString `json:"fullDescription,omitempty"`
 
-	// A unique identifer for the reporting descriptor in the form of a GUID.
+	// A unique identifier for the reporting descriptor in the form of a GUID.
 	Guid string `json:"guid,omitempty"`
 
 	// Provides the primary documentation for the report, useful when there is no online documentation.
@@ -928,7 +928,7 @@ type Result struct {
 	// An array of zero or more unique graph objects associated with the result.
 	Graphs []*Graph `json:"graphs,omitempty"`
 
-	// A stable, unique identifer for the result in the form of a GUID.
+	// A stable, unique identifier for the result in the form of a GUID.
 	Guid string `json:"guid,omitempty"`
 
 	// An absolute URI at which the result can be viewed.
@@ -1114,7 +1114,7 @@ type RunAutomationDetails struct {
 	// A description of the identity and role played within the engineering system by this object's containing run object.
 	Description *Message `json:"description,omitempty"`
 
-	// A stable, unique identifer for this object's containing run object in the form of a GUID.
+	// A stable, unique identifier for this object's containing run object in the form of a GUID.
 	Guid string `json:"guid,omitempty"`
 
 	// A hierarchical string that uniquely identifies this object's containing run object.
@@ -1169,7 +1169,7 @@ type StackFrame struct {
 // Suppression A suppression that is relevant to a result.
 type Suppression struct {
 
-	// A stable, unique identifer for the supression in the form of a GUID.
+	// A stable, unique identifier for the suppression in the form of a GUID.
 	Guid string `json:"guid,omitempty"`
 
 	// A string representing the justification for the suppression.
@@ -1293,7 +1293,7 @@ type ToolComponent struct {
 	// A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.
 	GlobalMessageStrings map[string]*MultiformatMessageString `json:"globalMessageStrings,omitempty"`
 
-	// A unique identifer for the tool component in the form of a GUID.
+	// A unique identifier for the tool component in the form of a GUID.
 	Guid string `json:"guid,omitempty"`
 
 	// The absolute URI at which information about this version of the tool component can be found.


### PR DESCRIPTION
According to the article https://go.dev/doc/faq#go_or_golang:

> A side note: Although the [official logo](https://go.dev/blog/go-brand) has two capital letters, the language name is written Go, not GO.
---
I propose to replace "GO" with "Go" in the description of the repo
<img width="323" alt="image" src="https://github.com/user-attachments/assets/7f965d29-c31a-4cb0-882f-70a62da80a0d">
